### PR TITLE
Allow for as many segments as needed 

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,5 @@
 {
-  "basePath": "/techradar",
+  "basePath": "/demo-techradar",
   "labels": {
     "title": "Technology Radar Demo",
     "subtitle": "This is just a demo of the AOE Technology Radar generator. You can use it to create your own radar."
@@ -60,16 +60,16 @@
     {
       "id": "s7",
       "title": "S7",
-      "description": "Technologies and practices that are not recommended for use in new projects.",
+      "description": "Technologies that are in the 'hold' phase, meaning they are stable but not actively developed.",
       "label": "Segment 7",
-      "color": "#9FC87E"
+      "color": "#2B2D42"
     },
     {
       "id": "s8",
       "title": "S8",
-      "description": "Technologies and practices that are considered obsolete or no longer relevant.",
+      "description": "Technologies that are in the 'assess' phase, meaning they are being evaluated for potential adoption.",
       "label": "Segment 8",
-      "color": "#FFD95F"
+      "color": "#8D99AE"
     }
   ]
 }

--- a/data/config.json
+++ b/data/config.json
@@ -3,5 +3,73 @@
   "labels": {
     "title": "Technology Radar Demo",
     "subtitle": "This is just a demo of the AOE Technology Radar generator. You can use it to create your own radar."
-  }
+  },
+  "colors": {
+    "foreground": "#000000",
+    "background": "#FFFFFF",
+    "highlight": "#029df7",
+    "content": "#000000",
+    "text": "#575757",
+    "link": "#029df7",
+    "border": "rgba(255, 255, 255, 0.1)",
+    "tag": "rgba(255, 255, 255, 0.1)"
+  },
+  "segments": [
+    {
+      "id": "s1",
+      "title": "S1",
+      "description": "Key software development methods and design patterns, covering everything from continuous integration and testing to architecture.",
+      "label": "Segment 1",
+      "color": "#BB3E00"
+    },
+    {
+      "id": "s2",
+      "title": "S2",
+      "description": "A range of software tools, from simple productivity enhancers to comprehensive project solutions, catering to various project needs.",
+      "label": "Segment 2",
+      "color": "#F7AD45"
+    },
+    {
+      "id": "s3",
+      "title": "S3",
+      "description": "Technologies and tools for software and infrastructure operations, including platforms and services for managing and scaling applications.",
+      "label": "Segment 3",
+      "color": "#657C6A"
+    },
+    {
+      "id": "s4",
+      "title": "S4",
+      "description": "A selection of programming languages, alongside essential frameworks for building a variety of custom software.",
+      "label": "Segment 4",
+      "color": "#A2B9A7"
+    },
+    {
+      "id": "s5",
+      "title": "S5",
+      "description": "Emerging technologies and concepts that are being explored for future adoption.",
+      "label": "Segment 5",
+      "color": "#FF3F33"
+    },
+    {
+      "id": "s6",
+      "title": "S6",
+      "description": "Technologies and practices that are being phased out or deprecated.",
+      "label": "Segment 6",
+      "color": "#075B5E"
+    },
+    {
+      "id": "s7",
+      "title": "S7",
+      "description": "Technologies and practices that are not recommended for use in new projects.",
+      "label": "Segment 7",
+      "color": "#9FC87E"
+    },
+    {
+      "id": "s8",
+      "title": "S8",
+      "description": "Technologies and practices that are considered obsolete or no longer relevant.",
+      "label": "Segment 8",
+      "color": "#FFD95F"
+    }
+  ]
 }

--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,5 @@
 {
-  "basePath": "/demo-techradar",
+  "basePath": "/techradar",
   "labels": {
     "title": "Technology Radar Demo",
     "subtitle": "This is just a demo of the AOE Technology Radar generator. You can use it to create your own radar."
@@ -17,59 +17,129 @@
   "segments": [
     {
       "id": "s1",
-      "title": "S1",
+      "title": "Techniques & Patterns",
       "description": "Key software development methods and design patterns, covering everything from continuous integration and testing to architecture.",
-      "label": "Segment 1",
+      "label": "Dimension 1",
       "color": "#BB3E00"
     },
     {
       "id": "s2",
-      "title": "S2",
+      "title": "Tools & Utilities",
       "description": "A range of software tools, from simple productivity enhancers to comprehensive project solutions, catering to various project needs.",
-      "label": "Segment 2",
+      "label": "Dimension 2",
       "color": "#F7AD45"
     },
     {
       "id": "s3",
-      "title": "S3",
+      "title": "Platforms & Infrastructure",
       "description": "Technologies and tools for software and infrastructure operations, including platforms and services for managing and scaling applications.",
-      "label": "Segment 3",
+      "label": "Dimension 3",
       "color": "#657C6A"
     },
     {
       "id": "s4",
-      "title": "S4",
+      "title": "Languages & Frameworks",
       "description": "A selection of programming languages, alongside essential frameworks for building a variety of custom software.",
-      "label": "Segment 4",
+      "label": "Dimension 4",
       "color": "#A2B9A7"
     },
     {
       "id": "s5",
-      "title": "S5",
+      "title": "Emerging Technologies",
       "description": "Emerging technologies and concepts that are being explored for future adoption.",
-      "label": "Segment 5",
+      "label": "Dimension 5",
       "color": "#FF3F33"
     },
     {
       "id": "s6",
-      "title": "S6",
+      "title": "Deprecated Practices",
       "description": "Technologies and practices that are being phased out or deprecated.",
-      "label": "Segment 6",
+      "label": "Dimension 6",
       "color": "#075B5E"
     },
     {
       "id": "s7",
-      "title": "S7",
+      "title": "On-Hold Technologies",
       "description": "Technologies that are in the 'hold' phase, meaning they are stable but not actively developed.",
-      "label": "Segment 7",
+      "label": "Dimension 7",
       "color": "#2B2D42"
     },
     {
       "id": "s8",
-      "title": "S8",
+      "title": "Under Assessment",
       "description": "Technologies that are in the 'assess' phase, meaning they are being evaluated for potential adoption.",
-      "label": "Segment 8",
+      "label": "Dimension 8",
       "color": "#8D99AE"
+    },
+    {
+      "id": "s9",
+      "title": "Data & Analytics",
+      "description": "Description for segment 9.",
+      "label": "Dimension 9",
+      "color": "#FF6347"
+    },
+    {
+      "id": "s10",
+      "title": "Security & Compliance",
+      "description": "Description for segment 10.",
+      "label": "Dimension 10",
+      "color": "#4682B4"
+    },
+    {
+      "id": "s11",
+      "title": "Mobile Development",
+      "description": "Description for segment 11.",
+      "label": "Dimension 11",
+      "color": "#32CD32"
+    },
+    {
+      "id": "s12",
+      "title": "AI & Machine Learning",
+      "description": "Description for segment 12.",
+      "label": "Dimension 12",
+      "color": "#FFD700"
+    },
+    {
+      "id": "s13",
+      "title": "Cloud Technologies",
+      "description": "Description for segment 13.",
+      "label": "Dimension 13",
+      "color": "#E6E6FA"
+    },
+    {
+      "id": "s14",
+      "title": "Frontend Development",
+      "description": "Description for segment 14.",
+      "label": "Dimension 14",
+      "color": "#D2B48C"
+    },
+    {
+      "id": "s15",
+      "title": "Backend Development",
+      "description": "Description for segment 15.",
+      "label": "Dimension 15",
+      "color": "#A0522D"
+    },
+    {
+      "id": "s16",
+      "title": "DevOps",
+      "description": "Description for segment 16.",
+      "label": "Dimension 16",
+      "color": "#808000"
+    },
+    {
+      "id": "s17",
+      "title": "UI/UX Design",
+      "description": "Description for segment 17.",
+      "label": "Dimension 17",
+      "color": "#708090"
+    },
+    {
+      "id": "s18",
+      "title": "Testing",
+      "description": "Description for segment 18.",
+      "label": "Dimension 18",
+      "color": "#C04000"
     }
   ]
 }

--- a/data/radar/2017-03-01/demo-1.md
+++ b/data/radar/2017-03-01/demo-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Demo 1"
 ring: assess
-quadrant: methods-and-patterns
+segment: methods-and-patterns
 tags: [coding]
 ---
 

--- a/data/radar/2017-03-01/demo-2.md
+++ b/data/radar/2017-03-01/demo-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Demo 2"
 ring: trial
-quadrant: platforms-and-operations
+segment: platforms-and-operations
 tags: [coding]
 ---
 

--- a/data/radar/2017-03-01/demo-3.md
+++ b/data/radar/2017-03-01/demo-3.md
@@ -1,7 +1,7 @@
 ---
 title: "Demo 3"
 ring: hold
-quadrant: tools
+segment: tools
 tags: [coding, frontend]
 ---
 

--- a/data/radar/2024-03-01/demo-2.md
+++ b/data/radar/2024-03-01/demo-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Demo 2"
 ring: adopt
-quadrant: platforms-and-operations
+segment: platforms-and-operations
 tags: [coding, backend]
 ---
 

--- a/data/radar/2024-03-01/demo-4.md
+++ b/data/radar/2024-03-01/demo-4.md
@@ -1,8 +1,0 @@
----
-title: "Demo 4"
-ring: trial
-quadrant: languages-and-frameworks
-tags: [new]
----
-
-This is a new demo entry. Items can [link](/methods-and-patterns/demo-1.html) to other items and replaces the old links with a html extension to the new link structure, whereas a new [link](/methods-and-patterns/demo-1/) should be untouched.

--- a/data/radar/2025-03-01/demo-1.md
+++ b/data/radar/2025-03-01/demo-1.md
@@ -1,0 +1,14 @@
+---
+title: "Demo 1"
+ring: assess
+segment: s1
+tags: [coding]
+---
+
+This is a demo entry. It is used to show how a radar item is written in Markdown format. The meta header is used to define the attributes of the item. The content of the file is used as the description of the item.
+
+```tsx
+// code higlighting works too
+const str = "Hello World!";
+console.log(str);
+```

--- a/data/radar/2025-03-01/demo-10.md
+++ b/data/radar/2025-03-01/demo-10.md
@@ -1,0 +1,8 @@
+---
+title: "Polyglot DSL Toolkit"
+ring: hold
+segment: s8
+tags: [dsl, polyglot, languages]
+---
+
+A toolkit for building domain-specific languages that can target multiple runtime environments. Mature but being held due to performance concerns.

--- a/data/radar/2025-03-01/demo-2.md
+++ b/data/radar/2025-03-01/demo-2.md
@@ -1,0 +1,8 @@
+---
+title: "Demo 2"
+ring: trial
+segment: s2
+tags: [coding]
+---
+
+This is a demo entry. It is used to show how a radar item is written in Markdown format. The meta header is used to define the attributes of the item. The content of the file is used as the description of the item.

--- a/data/radar/2025-03-01/demo-3.md
+++ b/data/radar/2025-03-01/demo-3.md
@@ -1,0 +1,8 @@
+---
+title: "Demo 3"
+ring: hold
+segment: s3
+tags: [coding, frontend]
+---
+
+This is a demo entry. It is used to show how a radar item is written in Markdown format. The meta header is used to define the attributes of the item. The content of the file is used as the description of the item.

--- a/data/radar/2025-03-01/demo-6.md
+++ b/data/radar/2025-03-01/demo-6.md
@@ -1,7 +1,7 @@
 ---
-title: "Demo 5"
+title: "Demo 6"
 ring: trial
-segment: s3
+segment: s4
 tags: [coding, segment]
 ---
 

--- a/data/radar/2025-03-01/demo-7.md
+++ b/data/radar/2025-03-01/demo-7.md
@@ -1,0 +1,8 @@
+---
+title: "Quantum Entanglement Framework"
+ring: assess
+segment: s5
+tags: [quantum, framework, experimental]
+---
+
+A highly experimental framework leveraging quantum entanglement principles for distributed computing. Still under heavy research.

--- a/data/radar/2025-03-01/demo-8.md
+++ b/data/radar/2025-03-01/demo-8.md
@@ -1,0 +1,8 @@
+---
+title: "AI-Powered Code Auditor"
+ring: trial
+segment: s6
+tags: [ai, code analysis, security]
+---
+
+An automated code auditing tool that uses AI to identify potential security vulnerabilities and code quality issues.

--- a/data/radar/2025-03-01/demo-9.md
+++ b/data/radar/2025-03-01/demo-9.md
@@ -1,0 +1,8 @@
+---
+title: "Serverless Container Orchestration"
+ring: adopt
+segment: s7
+tags: [serverless, containers, orchestration]
+---
+
+A fully managed platform for orchestrating serverless containers, providing scalability and cost-efficiency.

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -264,7 +264,7 @@ function postProcessItems(items: Item[]): {
 }
 
 async function main() {
-  // check segment length between 1 and 6
+  // check segment length between 1 and 18
   if (!segments.length || segments.length > 18) {
     errorHandler.processBuildErrors(
       ErrorType.InvalidSegmentLength,

--- a/src/components/Radar/Chart.tsx
+++ b/src/components/Radar/Chart.tsx
@@ -169,6 +169,43 @@ const _Chart: FC<ChartProps> = ({
     });
   };
 
+  const renderSegmentLabels = () => {
+    const numSegments = segments.length;
+    const labelRadius = center + 20; // Adjust this value to control distance from the radar
+
+    return segments.map((segment) => {
+      const { startAngle, endAngle } = calculateSegmentAngles(
+        segment.position,
+        numSegments,
+      );
+      const midAngle = startAngle + (endAngle - startAngle) / 2;
+      const { x, y } = polarToCartesian(labelRadius, midAngle);
+
+      const tolerance = 5;
+      let textAnchor = "middle";
+      if (midAngle > tolerance && midAngle < 180 - tolerance) {
+        textAnchor = "start";
+      } else if (midAngle > 180 + tolerance && midAngle < 360 - tolerance) {
+        textAnchor = "end";
+      }
+
+      return (
+        <text
+          key={segment.id}
+          x={x}
+          y={y}
+          textAnchor={textAnchor}
+          dominantBaseline="middle"
+          fontSize="14"
+          fontWeight="bold"
+          fill="var(--text)"
+        >
+          {segment.title}
+        </text>
+      );
+    });
+  };
+
   return (
     <svg
       className={className}
@@ -220,6 +257,7 @@ const _Chart: FC<ChartProps> = ({
       <g className={styles.ringLabels} data-key="labels">
         {renderRingLabels()}
       </g>
+      {renderSegmentLabels()}
     </svg>
   );
 };

--- a/src/components/Radar/Label.module.css
+++ b/src/components/Radar/Label.module.css
@@ -1,7 +1,4 @@
 .label {
-  width: 240px;
-  min-height: 180px;
-  position: absolute;
   transition: all 0.2s ease-in-out;
 }
 
@@ -24,67 +21,17 @@
   opacity: 0.75;
 }
 
-/* Positions for 12 segments */
-.position-1 {
-  top: -5%;
-  left: -5%;
-  transform: translate(-100%, -90%);
-}
-.position-2 {
-  top: -5%;
-  left: 50%;
-  transform: translate(-50%, -90%);
-}
-.position-3 {
-  top: -5%;
-  left: 105%;
-  transform: translate(-0%, -90%);
+@media (max-width: 968px) {
+  [data-segments="6"] .description {
+    display: none;
+  }
 }
 
-.position-4 {
-  top: 25%;
-  left: 105%;
-  transform: translate(0, -50%);
-}
-.position-5 {
-  top: 50%;
-  left: 105%;
-  transform: translate(0, -50%);
-}
-.position-6 {
-  top: 75%;
-  left: 105%;
-  transform: translate(0, -50%);
-}
-
-.position-7 {
-  top: 90%;
-  left: 105%;
-  transform: translate(-0%, -10%);
-}
-.position-8 {
-  top: 90%;
-  left: 50%;
-  transform: translate(-50%, -10%);
-}
-.position-9 {
-  top: 90%;
-  left: -5%;
-  transform: translate(-100%, -10%);
-}
-
-.position-10 {
-  top: 75%;
-  left: -5%;
-  transform: translate(-100%, -50%);
-}
-.position-11 {
-  top: 50%;
-  left: -5%;
-  transform: translate(-100%, -50%);
-}
-.position-12 {
-  top: 25%;
-  left: -5%;
-  transform: translate(-100%, -50%);
+@media (min-width: 1440px) {
+  [data-segments="6"] .position-5 {
+    left: -10%;
+  }
+  [data-segments="6"] .position-2 {
+    right: -10%;
+  }
 }

--- a/src/components/Radar/Label.module.css
+++ b/src/components/Radar/Label.module.css
@@ -1,5 +1,5 @@
 .label {
-  width: 240px;
+  width: 300px;
   min-height: 210px;
   position: absolute;
   top: 0;
@@ -26,16 +26,51 @@
   opacity: 0.75;
 }
 
-.position-1,
-.position-2 {
-  left: auto;
-  right: 0;
+.position-1 {
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -85%);
 }
 
-.position-2,
+.position-2 {
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -85%);
+}
+
 .position-3 {
-  top: auto;
-  bottom: 0;
+  top: 0;
+  left: 90%;
+  transform: translateY(-85%);
+}
+
+.position-4 {
+  top: 50%;
+  right: 0;
+  transform: translate(-50%, -85%);
+}
+
+.position-5 {
+  top: 50%;
+  left: 90%;
+  transform: translateY(-85%);
+}
+
+.position-6 {
+  left: 0;
+  top: 85%;
+  transform: translateX(-50%);
+}
+
+.position-7 {
+  left: 50%;
+  top: 85%;
+  transform: translateX(-50%);
+}
+
+.position-8 {
+  left: 90%;
+  top: 85%;
 }
 
 /** re-order the labels to top-left in some configurations */
@@ -47,12 +82,10 @@
   left: 0;
   right: auto;
 }
-
 [data-segments="5"] .position-3 {
   left: 50%;
   transform: translateX(-50%);
 }
-
 [data-segments="5"] .position-4 {
   top: auto;
   bottom: 0;

--- a/src/components/Radar/Label.module.css
+++ b/src/components/Radar/Label.module.css
@@ -1,9 +1,7 @@
 .label {
-  width: 300px;
-  min-height: 210px;
+  width: 240px;
+  min-height: 180px;
   position: absolute;
-  top: 0;
-  left: 0;
   transition: all 0.2s ease-in-out;
 }
 
@@ -26,103 +24,67 @@
   opacity: 0.75;
 }
 
+/* Positions for 12 segments */
 .position-1 {
-  top: 0;
-  left: 0;
-  transform: translate(-50%, -85%);
+  top: -5%;
+  left: -5%;
+  transform: translate(-100%, -90%);
 }
-
 .position-2 {
-  top: 0;
+  top: -5%;
   left: 50%;
-  transform: translate(-50%, -85%);
+  transform: translate(-50%, -90%);
 }
-
 .position-3 {
-  top: 0;
-  left: 90%;
-  transform: translateY(-85%);
+  top: -5%;
+  left: 105%;
+  transform: translate(-0%, -90%);
 }
 
 .position-4 {
-  top: 50%;
-  right: 0;
-  transform: translate(-50%, -85%);
+  top: 25%;
+  left: 105%;
+  transform: translate(0, -50%);
 }
-
 .position-5 {
   top: 50%;
-  left: 90%;
-  transform: translateY(-85%);
+  left: 105%;
+  transform: translate(0, -50%);
 }
-
 .position-6 {
-  left: 0;
-  top: 85%;
-  transform: translateX(-50%);
+  top: 75%;
+  left: 105%;
+  transform: translate(0, -50%);
 }
 
 .position-7 {
-  left: 50%;
-  top: 85%;
-  transform: translateX(-50%);
+  top: 90%;
+  left: 105%;
+  transform: translate(-0%, -10%);
 }
-
 .position-8 {
-  left: 90%;
-  top: 85%;
-}
-
-/** re-order the labels to top-left in some configurations */
-[data-segments="1"] .position-1,
-[data-segments="2"] .position-2,
-[data-segments="3"] .position-3 {
-  top: 0;
-  bottom: auto;
-  left: 0;
-  right: auto;
-}
-[data-segments="5"] .position-3 {
+  top: 90%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -10%);
 }
-[data-segments="5"] .position-4 {
-  top: auto;
-  bottom: 0;
+.position-9 {
+  top: 90%;
+  left: -5%;
+  transform: translate(-100%, -10%);
 }
 
-/* re-order the labels in the middle */
-[data-segments="6"] .position-2,
-[data-segments="6"] .position-5 {
-  bottom: auto;
+.position-10 {
+  top: 75%;
+  left: -5%;
+  transform: translate(-100%, -50%);
+}
+.position-11 {
   top: 50%;
-  transform: translateY(-50%);
+  left: -5%;
+  transform: translate(-100%, -50%);
 }
-
-[data-segments="6"] .position-3 {
-  left: auto;
-  right: 0;
-  bottom: 0;
-}
-
-[data-segments="6"] .position-4 {
-  left: 0;
-  right: auto;
-  top: auto;
-  bottom: 0;
-}
-
-@media (max-width: 968px) {
-  [data-segments="6"] .description {
-    display: none;
-  }
-}
-
-@media (min-width: 1440px) {
-  [data-segments="6"] .position-5 {
-    left: -10%;
-  }
-  [data-segments="6"] .position-2 {
-    right: -10%;
-  }
+.position-12 {
+  top: 25%;
+  left: -5%;
+  transform: translate(-100%, -50%);
 }

--- a/src/components/Radar/Radar.module.css
+++ b/src/components/Radar/Radar.module.css
@@ -1,21 +1,26 @@
 .radar {
-  padding: 0 15px 30px;
+  padding: 0 40px 30px;
   position: relative;
   transition: padding 200ms ease-in-out;
-  max-width: 50%;
-  margin: 0 auto;
 }
 
 .chart {
   display: block;
   max-width: 100%;
   height: auto;
-  margin: 250px auto 180px auto;
+  margin: 80px auto;
   fill: currentColor;
   border-radius: 100%;
   overflow: visible;
   box-shadow: rgba(0, 0, 0, 0.2) 0 4px 30px;
   border: 1px solid var(--border);
+}
+
+.labels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  padding: 20px 0;
 }
 
 .tooltip {

--- a/src/components/Radar/Radar.module.css
+++ b/src/components/Radar/Radar.module.css
@@ -8,7 +8,7 @@
   display: block;
   max-width: 100%;
   height: auto;
-  margin: 0 auto;
+  margin: 180px auto 120px auto;
   fill: currentColor;
   border-radius: 100%;
   overflow: visible;

--- a/src/components/Radar/Radar.module.css
+++ b/src/components/Radar/Radar.module.css
@@ -2,13 +2,15 @@
   padding: 0 15px 30px;
   position: relative;
   transition: padding 200ms ease-in-out;
+  max-width: 50%;
+  margin: 0 auto;
 }
 
 .chart {
   display: block;
   max-width: 100%;
   height: auto;
-  margin: 180px auto 120px auto;
+  margin: 250px auto 180px auto;
   fill: currentColor;
   border-radius: 100%;
   overflow: visible;

--- a/src/components/Radar/Radar.tsx
+++ b/src/components/Radar/Radar.tsx
@@ -93,11 +93,13 @@ export const Radar: FC<RadarProps> = ({
         rings={rings}
         items={items}
       />
+
       <div className={styles.labels}>
         {segments.map((segment) => (
           <Label key={segment.id} segment={segment} />
         ))}
       </div>
+
       <Legend />
       <span
         className={cn(styles.tooltip, tooltip.show && styles.isShown)}

--- a/src/components/Tags/Tags.module.css
+++ b/src/components/Tags/Tags.module.css
@@ -38,6 +38,6 @@
 
 .tags {
   text-align: center;
-  margin: 0 auto 60px;
+  margin: 40px auto 60px auto;
   max-width: 600px;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface Segment {
   label?: string; // only used in the radar labels
   color: string;
   position: number;
+  midAngle?: number;
 }
 
 export interface FooterLink {


### PR DESCRIPTION
This PR allows as many segments as desired in the radar.

The number of segments in determined in the `config.json`. Then the angles and display is automatically calculated to fit these segments in the radar.

The segment descriptions have been moved to a regular grid below the radar. This allows for more flexibility in their number while keeping a nice-looking radar and avoiding display nightmares.
The segment titles have been added around the circle for clarity.

The demo here is tested with 18 segments:

![screencapture-localhost-3001-demo-techradar-2025-06-25-16_27_22](https://github.com/user-attachments/assets/cde8fbd7-1c7c-459b-ab4c-0f8c4fd8ed6c)

Fixes #2 